### PR TITLE
Fix Graph API headers

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -165,10 +165,8 @@ function sendEmailViaGraph($access_token, $sender_email, $recipient_email, $subj
     
     $options = [
         'http' => [
-            'header' => [
-                "Authorization: Bearer $access_token",
-                "Content-Type: application/json"
-            ],
+            'header' => "Authorization: Bearer $access_token\r\n" .
+                        "Content-Type: application/json\r\n",
             'method' => 'POST',
             'content' => json_encode($email_data)
         ]

--- a/debug-contact.php
+++ b/debug-contact.php
@@ -200,10 +200,8 @@ function sendEmailViaGraph($access_token, $sender_email, $recipient_email, $subj
     
     $options = [
         'http' => [
-            'header' => [
-                "Authorization: Bearer $access_token",
-                "Content-Type: application/json"
-            ],
+            'header' => "Authorization: Bearer $access_token\r\n" .
+                        "Content-Type: application/json\r\n",
             'method' => 'POST',
             'content' => json_encode($email_data),
             'ignore_errors' => true

--- a/send-test-email.php
+++ b/send-test-email.php
@@ -87,10 +87,8 @@ function sendTestEmail($access_token, $sender_email, $recipient_email) {
     
     $options = [
         'http' => [
-            'header' => [
-                "Authorization: Bearer $access_token",
-                "Content-Type: application/json"
-            ],
+            'header' => "Authorization: Bearer $access_token\r\n" .
+                        "Content-Type: application/json\r\n",
             'method' => 'POST',
             'content' => json_encode($email_data),
             'ignore_errors' => true


### PR DESCRIPTION
## Summary
- use newline separated HTTP header strings for Graph API requests

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840874651088333b8a5e568eaca8e53