### PR TITLE
Reorder team members

### DIFF
--- a/wolthers_team.html
+++ b/wolthers_team.html
@@ -966,6 +966,20 @@
                         <div class="team-description">Oversees our Guatemala and Colombia labs, frequently traveling across Brazil and Latin America while supporting marketing efforts.</div>
                     </div>
                     <div class="team-card">
+                        <div class="team-photo">TS</div>
+                        <div class="team-name">Tom Sullivan</div>
+                        <div class="team-position" data-lang-key="seniorTrader">Senior Trader</div>
+                        <div class="team-specialty trader">Trading Expert</div>
+                        <div class="team-description">Seasoned trader managing key accounts and driving growth in the Brazilian market.</div>
+                    </div>
+                    <div class="team-card">
+                        <div class="team-photo">NB</div>
+                        <div class="team-name">Natalia Barletta</div>
+                        <div class="team-position" data-lang-key="headLogisticsTrading">Head of Logistics &amp; Trading</div>
+                        <div class="team-specialty logistics">Logistics &amp; Trading Lead</div>
+                        <div class="team-description">Veteran of multinational shipping lines who ensures timely samples, secures competitive freight quotes and assists with trading.</div>
+                    </div>
+                    <div class="team-card">
                         <div class="team-photo">EG</div>
                         <div class="team-name">Edgar André Gomes</div>
                         <div class="team-position" data-lang-key="partnerQualityDirector">Associate & Partner - Quality Control Director</div>
@@ -1059,20 +1073,6 @@
                         <div class="team-position" data-lang-key="logistics">Logistics</div>
                         <div class="team-specialty logistics">Logistics Coordinator</div>
                         <div class="team-description">Ensuring smooth logistics operations and maintaining high standards in supply chain management.</div>
-                    </div>
-                    <div class="team-card">
-                        <div class="team-photo">TS</div>
-                        <div class="team-name">Tom Sullivan</div>
-                        <div class="team-position" data-lang-key="seniorTrader">Senior Trader</div>
-                        <div class="team-specialty trader">Trading Expert</div>
-                        <div class="team-description">Seasoned trader managing key accounts and driving growth in the Brazilian market.</div>
-                    </div>
-                    <div class="team-card">
-                        <div class="team-photo">NB</div>
-                        <div class="team-name">Natalia Barletta</div>
-                        <div class="team-position" data-lang-key="headLogisticsTrading">Head of Logistics &amp; Trading</div>
-                        <div class="team-specialty logistics">Logistics &amp; Trading Lead</div>
-                        <div class="team-description">Veteran of multinational shipping lines who ensures timely samples, secures competitive freight quotes and assists with trading.</div>
                     </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- move Tom Sullivan and Natalia Barletta directly after Svenn Wolthers in the Santos team grid

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841d57f04048333a64b30e200f1ecd8