### PR TITLE
Update team titles and language switcher

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -102,6 +102,12 @@ body {
     gap: 10px;
 }
 
+.footer-language-switcher {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
 .lang-btn {
     background: none;
     border: 1px solid rgba(255, 255, 255, 0.3);
@@ -113,11 +119,14 @@ body {
     transition: all 0.3s ease;
 }
 
-.lang-btn:hover,
 .lang-btn.active {
     background: #d4af37;
     border-color: #d4af37;
     color: #1a3d1e;
+}
+
+.lang-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
 }
 
 /* ===== MAIN HEADER COMPONENT ===== */

--- a/index.html
+++ b/index.html
@@ -336,16 +336,10 @@
                     <button class="footer-search-btn" aria-label="Perform footer search">🔍</button>
                 </div>
                 
-                <div class="footer-language-dropdown">
-                    <button class="footer-language-btn" aria-haspopup="true" aria-expanded="false">
-                        <span id="current-lang">EN</span>
-                        <span class="dropdown-arrow" aria-hidden="true">▼</span>
-                    </button>
-                    <div class="footer-language-dropdown-content">
-                        <a href="#" data-lang="en">EN</a>
-                        <a href="#" data-lang="pt">PT</a>
-                        <a href="#" data-lang="es">ES</a>
-                    </div>
+                <div class="footer-language-switcher">
+                    <button class="lang-btn" data-lang="en">EN</button>
+                    <button class="lang-btn" data-lang="pt">PT</button>
+                    <button class="lang-btn" data-lang="es">ES</button>
                 </div>
             </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -283,8 +283,8 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Language switcher functionality
     function setupLanguageSwitcher() {
-        const langButtons = document.querySelectorAll('.lang-btn');
-        const footerLangLinks = document.querySelectorAll('.footer-language-dropdown-content a');
+        const langButtons = document.querySelectorAll('.language-switcher .lang-btn');
+        const footerLangLinks = document.querySelectorAll('.footer-language-switcher .lang-btn');
 
         function applyTranslations(lang) {
             if (typeof translations === 'undefined') return;
@@ -308,11 +308,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 btn.classList.toggle('active', btn.dataset.lang === lang);
             });
 
-            // Update footer current language
-            const currentLangSpan = document.getElementById('current-lang');
-            if (currentLangSpan) {
-                currentLangSpan.textContent = lang.toUpperCase();
-            }
+            // Highlight active footer button
+            footerLangLinks.forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.lang === lang);
+            });
 
             // Apply translations if available
             applyTranslations(lang);

--- a/wolthers_team.html
+++ b/wolthers_team.html
@@ -979,7 +979,7 @@
                             <img src="images/members/Rasmus_Wolthers.png" alt="Rasmus Wolthers" onerror="this.style.display='none'; this.parentElement.innerHTML='RW';">
                         </div>
                         <div class="team-name">Rasmus Wolthers</div>
-                        <div class="team-position" data-lang-key="ceoTitle">Chief Executive Officer</div>
+                        <div class="team-position" data-lang-key="ceoTitle">Partner &amp; Chief Executive Officer</div>
                         <div class="team-specialty trader" data-lang-key="generation3rd">3rd Generation Leader</div>
                         <div class="team-description">Leading Wolthers & Associates into the modern era of coffee trading with a focus on sustainability, transparency, and innovation. Responsible for strategic direction and global expansion.</div>
                     </div>
@@ -995,7 +995,7 @@
                             <img src="images/members/Daniel_Wolthers.png" alt="Daniel Wolthers" onerror="this.style.display='none'; this.parentElement.innerHTML='DW';">
                         </div>
                         <div class="team-name">Daniel Wolthers</div>
-                        <div class="team-position">Partner &amp; COO</div>
+                        <div class="team-position" data-lang-key="tradingDirectorTitle">Partner &amp; Chief Operating Officer</div>
                         <div class="team-specialty trader" data-lang-key="generation3rdSimple">3rd Generation</div>
                         <div class="team-description" data-lang-key="danielDescription">Partner and COO overseeing company operations and trading activities with deep knowledge of supply chains and strategic development. He is also a Nespresso Cluster Administrator.</div>
                     </div>
@@ -1019,7 +1019,7 @@
                     <div class="team-card">
                         <div class="team-photo">SW</div>
                         <div class="team-name">Svenn Wolthers</div>
-                        <div class="team-position">Partner - Labs &amp; Marketing</div>
+                        <div class="team-position" data-lang-key="labsMarketing">Partner, Labs &amp; Marketing</div>
                         <div class="team-specialty trader" data-lang-key="generation3rdSimple">3rd Generation</div>
                         <div class="team-description" data-lang-key="svennDescription">Oversees our Guatemala and Colombia labs, frequently traveling across Brazil and Latin America while supporting marketing efforts. Svenn is also a great host and experienced inland travel agent.</div>
                     </div>
@@ -1028,7 +1028,7 @@
                         <div class="team-name">Tom Sullivan</div>
                         <div class="team-position" data-lang-key="seniorTrader">Senior Trader</div>
                         <div class="team-specialty trader">Trading Expert</div>
-                        <div class="team-description">Seasoned trader managing key accounts and driving growth in the Brazilian market.</div>
+                        <div class="team-description">Seasoned trading expert with extensive experience in global coffee markets. Manages key international accounts, develops strategic trading relationships, and drives worldwide growth initiatives. Deep understanding of market dynamics and risk management across multiple coffee origins.</div>
                     </div>
                     <div class="team-card">
                         <div class="team-photo">NB</div>
@@ -1058,7 +1058,7 @@
                             <img src="images/members/Petter_Anderson.png" alt="Petter Anderson" onerror="this.style.display='none'; this.parentElement.innerHTML='PA';">
                         </div>
                         <div class="team-name">Petter Anderson</div>
-                        <div class="team-position">Quality Support Analyst</div>
+                        <div class="team-position" data-lang-key="qualitySupportAnalyst">Quality Support Analyst</div>
                         <div class="team-specialty quality">Quality Expert</div>
                         <div class="team-description">Skilled quality analyst contributing to our comprehensive quality control processes and standards.</div>
                     </div>
@@ -1067,7 +1067,7 @@
                             <img src="images/members/Victor_Paula.png" alt="Victor De Paula" onerror="this.style.display='none'; this.parentElement.innerHTML='VP';">
                         </div>
                         <div class="team-name">Victor De Paula</div>
-                        <div class="team-position">Quality Support Analyst</div>
+                        <div class="team-position" data-lang-key="qualitySupportAnalyst">Quality Support Analyst</div>
                         <div class="team-specialty quality">Quality Expert</div>
                         <div class="team-description">Dedicated quality analyst ensuring consistent quality standards across all coffee evaluations.</div>
                     </div>
@@ -1161,7 +1161,7 @@
                             <img src="images/members/Yara_Melo.png" alt="Yara Melo" onerror="this.style.display='none'; this.parentElement.innerHTML='YM';">
                         </div>
                         <div class="team-name">Yara Melo</div>
-                        <div class="team-position" data-lang-key="aaaInclusivePartner">Nespresso Field Code of Conduct</div>
+                        <div class="team-position" data-lang-key="aaaInclusivePartner">Nespresso Field Code of Conduct Specialist</div>
                         <div class="team-specialty agronomist">Inclusion Specialist</div>
                         <div class="team-description">Promoting inclusive practices, ensuring diverse participation in our sustainable coffee programs, and verifying that all farm practices comply with local laws and global expectations.</div>
                     </div>
@@ -1188,7 +1188,7 @@
                             <img src="images/members/Kamila_Côrtes.png" alt="Kamila Côrtes" onerror="this.style.display='none'; this.parentElement.innerHTML='KC';">
                         </div>
                         <div class="team-name">Kamila Côrtes</div>
-                        <div class="team-position" data-lang-key="aaaInclusivePartner">Nespresso Field Code of Conduct</div>
+                        <div class="team-position" data-lang-key="aaaInclusivePartner">Nespresso Field Code of Conduct Specialist</div>
                         <div class="team-specialty agronomist">Community Liaison</div>
                         <div class="team-description">Building inclusive partnerships and fostering community engagement in sustainable coffee initiatives.</div>
                     </div>
@@ -1373,16 +1373,10 @@
                     <button class="footer-search-btn">🔍</button>
                 </div>
                 
-                <div class="footer-language-dropdown">
-                    <button class="footer-language-btn">
-                        <span id="current-lang">EN</span>
-                        <span class="dropdown-arrow">▼</span>
-                    </button>
-                    <div class="footer-language-dropdown-content">
-                        <a href="#" onclick="changeFooterLanguage('en')">EN</a>
-                        <a href="#" onclick="changeFooterLanguage('pt')">PT</a>
-                        <a href="#" onclick="changeFooterLanguage('es')">ES</a>
-                    </div>
+                <div class="footer-language-switcher">
+                    <button class="lang-btn" data-lang="en">EN</button>
+                    <button class="lang-btn" data-lang="pt">PT</button>
+                    <button class="lang-btn" data-lang="es">ES</button>
                 </div>
             </div>
 
@@ -1457,9 +1451,9 @@
                 // Leadership Section
                 leadershipTitle: 'Leadership Team',
                 leadershipSubtitle: 'Three generations of coffee expertise guiding our global operations',
-                ceoTitle: 'Chief Executive Officer',
+                ceoTitle: 'Partner & Chief Executive Officer',
                 founderTitle: 'Chairman',
-                tradingDirectorTitle: 'Partner & COO',
+                tradingDirectorTitle: 'Partner & Chief Operating Officer',
                 generation2nd: '2nd Generation',
                 generation3rd: '3rd Generation Leader',
                 generation3rdSimple: '3rd Generation',
@@ -1482,9 +1476,10 @@
                 logistics: 'Logistics',
                 adminAssistant: 'Administrative Assistant',
                 agronomist: 'Agronomist / Technical Assistant',
-                labsMarketing: 'Partner - Labs & Marketing',
+                labsMarketing: 'Partner, Labs & Marketing',
                 partnerQualityDirector: 'Partner & Quality Control Director',
                 seniorTrader: 'Senior Trader',
+                qualitySupportAnalyst: 'Quality Support Analyst',
                 headLogisticsTrading: 'Head of Logistics & Trading',
                 
                 // AAA Team
@@ -1492,7 +1487,7 @@
                 aaaTeamSubtitle: 'Dedicated to sustainable and responsible coffee production',
                 aaaAgronomist: 'Nespresso AAA Field Agronomist',
                 aaaFieldCoordinator: 'Nespresso AAA Field Coordinator',
-                aaaInclusivePartner: 'Nespresso Field Code of Conduct',
+                aaaInclusivePartner: 'Nespresso Field Code of Conduct Specialist',
                 
                 // Contact Section
                 contactTitle: 'Contact Us',
@@ -1562,9 +1557,9 @@
                 // Leadership Section
                 leadershipTitle: 'Equipe de Liderança',
                 leadershipSubtitle: 'Três gerações de expertise em café guiando nossas operações globais',
-                ceoTitle: 'Diretor Executivo',
+                ceoTitle: 'Sócio e Diretor Executivo',
                 founderTitle: 'Presidente do Conselho',
-                tradingDirectorTitle: 'Sócio e COO',
+                tradingDirectorTitle: 'Sócio e Diretor de Operações',
                 generation2nd: '2ª Geração',
                 generation3rd: 'Líder da 3ª Geração',
                 generation3rdSimple: '3ª Geração',
@@ -1587,9 +1582,10 @@
                 logistics: 'Logística',
                 adminAssistant: 'Assistente Administrativo',
                 agronomist: 'Agrônomo / Assistente Técnico',
-                labsMarketing: 'Sócio - Laboratórios & Marketing',
+                labsMarketing: 'Sócio, Laboratórios & Marketing',
                 partnerQualityDirector: 'Sócio - Diretor de Controle de Qualidade',
                 seniorTrader: 'Trader Sênior',
+                qualitySupportAnalyst: 'Analista de Suporte de Qualidade',
                 headLogisticsTrading: 'Chefe de Logística e Trading',
                 
                 // AAA Team
@@ -1597,7 +1593,7 @@
                 aaaTeamSubtitle: 'Dedicada à produção sustentável e responsável de café',
                 aaaAgronomist: 'Agrônomo de Campo Nespresso AAA',
                 aaaFieldCoordinator: 'Coordenador de Campo Nespresso AAA',
-                aaaInclusivePartner: 'Código de Conduta de Campo Nespresso',
+                aaaInclusivePartner: 'Especialista em Código de Conduta Nespresso',
                 
                 // Contact Section
                 contactTitle: 'Entre em Contato',
@@ -1667,9 +1663,9 @@
                 // Leadership Section
                 leadershipTitle: 'Equipo de Liderazgo',
                 leadershipSubtitle: 'Tres generaciones de experiencia en café guiando nuestras operaciones globales',
-                ceoTitle: 'Director Ejecutivo',
+                ceoTitle: 'Socio y Director Ejecutivo',
                 founderTitle: 'Presidente',
-                tradingDirectorTitle: 'Socio y COO',
+                tradingDirectorTitle: 'Socio y Director de Operaciones',
                 generation2nd: '2ª Generación',
                 generation3rd: 'Líder de 3ª Generación',
                 generation3rdSimple: '3ª Generación',
@@ -1692,9 +1688,10 @@
                 logistics: 'Logística',
                 adminAssistant: 'Asistente Administrativo',
                 agronomist: 'Agrónomo / Asistente Técnico',
-                labsMarketing: 'Socio - Laboratorios y Marketing',
+                labsMarketing: 'Socio, Laboratorios y Marketing',
                 partnerQualityDirector: 'Socio - Director de Control de Calidad',
                 seniorTrader: 'Trader Senior',
+                qualitySupportAnalyst: 'Analista de Soporte de Calidad',
                 headLogisticsTrading: 'Jefa de Logística y Trading',
                 
                 // AAA Team
@@ -1702,7 +1699,7 @@
                 aaaTeamSubtitle: 'Dedicado a la producción sostenible y responsable de café',
                 aaaAgronomist: 'Agrónomo de Campo Nespresso AAA',
                 aaaFieldCoordinator: 'Coordinador de Campo Nespresso AAA',
-                aaaInclusivePartner: 'Código de Conducta de Campo Nespresso',
+                aaaInclusivePartner: 'Especialista en Código de Conducta Nespresso',
                 
                 // Contact Section
                 contactTitle: 'Contáctanos',
@@ -1750,11 +1747,15 @@
             currentLanguage = lang;
             
             // Update active button in header
-            document.querySelectorAll('.lang-btn').forEach(btn => {
+            document.querySelectorAll('.language-switcher .lang-btn').forEach(btn => {
                 btn.classList.remove('active');
                 if (btn.textContent.toLowerCase() === lang) {
                     btn.classList.add('active');
                 }
+            });
+
+            document.querySelectorAll('.footer-language-switcher .lang-btn').forEach(btn => {
+                btn.classList.toggle('active', btn.dataset.lang === lang);
             });
             
             // Update all elements with data-lang-key
@@ -1769,25 +1770,23 @@
                 }
             });
             
-            // Update footer language button
-            const footerLangBtn = document.getElementById('current-lang');
-            if (footerLangBtn) {
-                footerLangBtn.textContent = lang.toUpperCase();
-            }
+            // no dropdown element anymore
             
             // Store language preference
             localStorage.setItem('preferredLanguage', lang);
         }
 
-        // Function to change footer language (syncs with header)
-        function changeFooterLanguage(lang) {
-            switchLanguage(lang);
-        }
 
         // Load saved language preference on page load
         document.addEventListener('DOMContentLoaded', function() {
             const savedLang = localStorage.getItem('preferredLanguage') || 'en';
             switchLanguage(savedLang);
+
+            document.querySelectorAll('.footer-language-switcher .lang-btn').forEach(btn => {
+                btn.addEventListener('click', function() {
+                    switchLanguage(this.dataset.lang);
+                });
+            });
         });
 
         // Scroll functionality for top header


### PR DESCRIPTION
## Summary
- refine language switcher styles and logic so only the active language button is highlighted
- replace footer language dropdown with button set
- update team member job titles and add missing translation keys
- sync Portuguese and Spanish translations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684332a9f0c083339c548316d9943579