### PR TITLE
Fix Nespresso itinerary styling and timeline

### DIFF
--- a/trip-itineraries/2025/nespresso-july/index.html
+++ b/trip-itineraries/2025/nespresso-july/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Source+Sans+Pro:wght@400;600;700&family=Marcellus&family=DM+Sans:wght@400;500;600&family=Version+72:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../../assets/css/trip-styles.css">
+    <link rel="stylesheet" href="../../assets/css/trip_itinerary.css">
 </head>
 <body>
     <div class="container">
@@ -147,7 +147,7 @@
 
     <button class="print-button">Imprimir</button>
 
-    <script src="../../assets/js/trip-scripts.js"></script>
+    <script src="../../assets/js/trip_itinerary.js"></script>
     <script>
         // Trip-specific event data for Nespresso July 2025
         window.eventsByDate = {

--- a/trip-itineraries/assets/css/trip_itinerary.css
+++ b/trip-itineraries/assets/css/trip_itinerary.css
@@ -129,11 +129,20 @@ body {
     padding: 30px;
 }
 
+
 .day {
     margin-bottom: 40px;
     border-left: 4px solid var(--light-green);
     padding-left: 20px;
     position: relative;
+}
+
+.day.current {
+    border-left-color: #D4AF37;
+}
+
+.day.past {
+    border-left-color: #555;
 }
 
 .day::before {
@@ -147,6 +156,14 @@ body {
     border-radius: 50%;
 }
 
+.day.current::before {
+    background: #D4AF37;
+}
+
+.day.past::before {
+    background: #555;
+}
+
 .day-header {
     background: linear-gradient(90deg, var(--medium-green), var(--light-green));
     color: var(--white);
@@ -157,6 +174,16 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
+}
+
+.day.current .day-header {
+    background: linear-gradient(90deg, #D4AF37, #FFE08A);
+    color: #333;
+}
+
+.day.past .day-header {
+    background: #555;
+    color: #fff;
 }
 
 .day-date {
@@ -200,18 +227,19 @@ body {
     position: relative;
 }
 
+
 .activity.past {
-    background: #e8e8e8;
-    color: #666;
-    border-left-color: #999;
+    background: #555;
+    color: #fff;
+    border-left-color: #777;
 }
 
 .activity.past .activity-time {
-    color: #666 !important;
+    color: #fff !important;
 }
 
 .activity.past .activity-description {
-    color: #666 !important;
+    color: #fff !important;
 }
 
 .activity.current {

--- a/trip-itineraries/assets/js/trip_itinerary.js
+++ b/trip-itineraries/assets/js/trip_itinerary.js
@@ -79,6 +79,9 @@ function updateTimelineStatus() {
         const isPast = dayDate < now && !isToday;
         
         if (isToday) {
+            day.classList.add('current');
+            day.classList.remove('past');
+
             let currentActivityFound = false;
             
             activities.forEach(activity => {
@@ -99,11 +102,15 @@ function updateTimelineStatus() {
                 }
             });
         } else if (isPast) {
+            day.classList.add('past');
+            day.classList.remove('current');
+
             activities.forEach(activity => {
                 activity.classList.add('past');
                 activity.classList.remove('current');
             });
         } else {
+            day.classList.remove('past', 'current');
             activities.forEach(activity => {
                 activity.classList.remove('past', 'current');
             });


### PR DESCRIPTION
## Summary
- link to correct itinerary CSS and JS assets
- style current and past days
- darken past activities
- highlight the active day and meeting via JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848554688dc8333b4a090f07b4852b3