### PR TITLE
Remove conclusion box style

### DIFF
--- a/trip-itineraries/2025/nespresso-july/index.html
+++ b/trip-itineraries/2025/nespresso-july/index.html
@@ -137,9 +137,7 @@
             </div>
 
             <div class="trip-conclusion">
-                <div class="conclusion-content">
-                    <h2>Fim da Viagem</h2>
-                </div>
+                Fim da Viagem / end of coffee trip
             </div>
         </div>
     </div>

--- a/trip-itineraries/assets/css/trip_itinerary.css
+++ b/trip-itineraries/assets/css/trip_itinerary.css
@@ -310,13 +310,11 @@ body {
 }
 
 .trip-conclusion {
-    background: #9b8261;
-    color: var(--white);
-    padding: 40px 30px;
+    background: none;
+    color: #9b8261;
+    padding: 0;
     text-align: center;
     margin: 40px 0;
-    border-radius: 0;
-    box-shadow: none;
 }
 
 .conclusion-content h2 {
@@ -509,10 +507,9 @@ body {
     }
     
     .trip-conclusion {
-        border-radius: 0;
-        margin-left: -20px;
-        margin-right: -20px;
-        padding: 30px 20px;
+        padding: 0;
+        margin-left: 0;
+        margin-right: 0;
     }
     
     .conclusion-content h2 {


### PR DESCRIPTION
## Summary
- restyle the itinerary conclusion section to no longer use a box
- update the Nespresso itinerary text to "Fim da Viagem / end of coffee trip"

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68485e2caf748333b0f3131418167cf2