### PR TITLE
Add Microsoft auth module and page bootstrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,6 +386,6 @@
         </div>
     </footer>
 
-    <script src="js/main.js"></script>
+    <script type="module" src="js/pages/index.bootstrap.js"></script>
 </body>
 </html>

--- a/js/microsoft-auth.js
+++ b/js/microsoft-auth.js
@@ -1,0 +1,27 @@
+import { PublicClientApplication } from 'https://alcdn.msauth.net/browser/2.37.1/js/msal-browser.esm.min.js';
+
+const msalConfig = {
+  auth: {
+    clientId: 'YOUR_CLIENT_ID',
+    redirectUri: window.location.origin,
+  }
+};
+
+const msalInstance = new PublicClientApplication(msalConfig);
+
+export function login() {
+  return msalInstance.loginPopup().then(response => {
+    console.log('Microsoft login successful', response);
+    return response;
+  }).catch(err => {
+    console.error('Microsoft login error', err);
+    throw err;
+  });
+}
+
+export function logout() {
+  msalInstance.logoutPopup();
+}
+
+// Automatically prompt sign in when the module is loaded
+login();

--- a/js/pages/index.bootstrap.js
+++ b/js/pages/index.bootstrap.js
@@ -1,0 +1,2 @@
+import '../microsoft-auth.js';
+import '../main.js';


### PR DESCRIPTION
## Summary
- include a Microsoft authentication helper using MSAL
- create a bootstrap module to load MS auth and existing main logic
- load the bootstrap module from `index.html`

## Testing
- `node -e "import('./js/microsoft-auth.js').then(()=>console.log('ok')).catch(e=>console.error(e));" 2>&1 | head` *(fails: Only URLs with a scheme in: file and data are supported)*

------
https://chatgpt.com/codex/tasks/task_e_685ea8ee0ab48333866bf171ed52caba