### PR TITLE
Fix updateUser to check existence

### DIFF
--- a/api/users.php
+++ b/api/users.php
@@ -57,9 +57,19 @@ function updateUser($id) {
 
     try {
         $pdo = getPDO();
+        // Ensure the user exists before attempting to update
+        $checkStmt = $pdo->prepare('SELECT COUNT(*) FROM users WHERE id = :id');
+        $checkStmt->execute([':id' => $id]);
+        if ($checkStmt->fetchColumn() == 0) {
+            http_response_code(404);
+            echo json_encode(['error' => 'Not found']);
+            return;
+        }
+
         $sql = 'UPDATE users SET ' . implode(', ', $fields) . ' WHERE id = :id';
         $stmt = $pdo->prepare($sql);
         $stmt->execute($params);
+
         echo json_encode(['success' => true]);
     } catch (Exception $e) {
         http_response_code(500);


### PR DESCRIPTION
## Summary
- handle nonexistent IDs when updating a user

## Testing
- `php -l api/users.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eca1ad4ec8333a11461103273dd29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when updating users by returning a clear "Not found" message if the specified user does not exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->